### PR TITLE
fix Assets bug

### DIFF
--- a/CustomExtensions.WinUI/ExtensionAssembly.cs
+++ b/CustomExtensions.WinUI/ExtensionAssembly.cs
@@ -28,6 +28,10 @@ internal partial class ExtensionAssembly : IExtensionAssembly
 		ForeignAssembly = Assembly.LoadFrom(assemblyPath);
 		ForeignAssemblyDir = Path.GetDirectoryName(ForeignAssembly.Location.AssertDefined()).AssertDefined();
 		ForeignAssemblyName = ForeignAssembly.GetName().Name.AssertDefined();
+		var appxExtension = Path.Combine(ForeignAssemblyDir, ForeignAssemblyName);
+		var appxHost = Path.Combine(HostingProcessDir, ForeignAssemblyName);
+		if (Directory.Exists(appxExtension) && !Directory.Exists(appxHost))
+			Directory.CreateSymbolicLink(appxHost, appxExtension);
 	}
 
 	public async Task LoadAsync()


### PR DESCRIPTION
- https://github.com/dnchattan/winui-extensions/issues/4

It is not found the Assets Folder of Extension
I fix this bug by Creating Hard Link From Extension Assets  To App Host Appx
maybe it only in NTFS 

✅All Right in Unpackaged/Packaged, Debug/Release